### PR TITLE
Refactor forum pending and approved posts list to make nested routes …

### DIFF
--- a/src/components/App/Routes.js
+++ b/src/components/App/Routes.js
@@ -2,7 +2,7 @@ import React from 'react';
 import * as ROUTES from '../../constants/routes';
 import AccountPage from '../Account';
 import AdminPage from '../Admin';
-import { ForumHomePage } from '../Forum';
+import ForumHomePage from '../Forum';
 import PasswordForgetPage from '../PasswordForget';
 import {
   CategoryPage, NewCategoryPage, NewResourcePage, ResourcePage, ResourcesPage,

--- a/src/components/Forum/ForumApprovedPosts.js
+++ b/src/components/Forum/ForumApprovedPosts.js
@@ -1,0 +1,81 @@
+import React, { useMemo } from 'react';
+import { Route, Switch } from 'react-router-dom';
+import { useTheme } from '@material-ui/core';
+import DeleteIcon from '@material-ui/icons/Delete';
+import EditIcon from '@material-ui/icons/Edit';
+import ReplyIcon from '@material-ui/icons/Reply';
+import { ForumPostsListByApproval, FormattedReferencedDataField, RepliesChip } from './ForumPostsList';
+
+const approvedPostsListColumns = [
+  {
+    id: 'userID',
+    label: 'User',
+    format: (value) => (
+      <FormattedReferencedDataField
+        collection="users"
+        id={value}
+        field="displayName"
+        notFoundMessage="User not found"
+        render={(item) => <>{item}</>}
+      />
+    ),
+  },
+  {
+    id: 'title',
+    label: 'Post Title',
+  },
+  {
+    id: 'categoryID',
+    label: 'Category',
+    format: (value) => (
+      <FormattedReferencedDataField
+        collection="forum_categories"
+        id={value}
+        field="title"
+        notFoundMessage="Category not found"
+        render={(item) => <>{item}</>}
+      />
+    ),
+  },
+  {
+    id: 'approvedAt',
+    label: 'Approved At',
+    format: (value) => (value ? value.toDate().toLocaleString() : 'Date not found'),
+  },
+  {
+    id: 'id',
+    label: 'Replies',
+    format: (value) => <RepliesChip postID={value} />,
+  },
+];
+
+export default function ForumApprovedPostsList() {
+  const theme = useTheme();
+
+  const approvedActionButtons = useMemo(() => ([
+    {
+      Icon: ReplyIcon,
+    },
+    {
+      Icon: EditIcon,
+      color: theme.palette.text.main,
+    },
+    {
+      Icon: DeleteIcon,
+      color: theme.palette.error.main,
+    },
+  ]), [theme.palette.error.main, theme.palette.text.main]);
+
+  return (
+    <Switch>
+      {/* Nested route to an individual post goes here */}
+      <Route exact>
+        <ForumPostsListByApproval
+          approved
+          columns={approvedPostsListColumns}
+          actionButtons={approvedActionButtons}
+        />
+      </Route>
+    </Switch>
+  );
+}

--- a/src/components/Forum/ForumApprovedPosts.js
+++ b/src/components/Forum/ForumApprovedPosts.js
@@ -1,42 +1,12 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { useTheme } from '@material-ui/core';
 import DeleteIcon from '@material-ui/icons/Delete';
 import EditIcon from '@material-ui/icons/Edit';
 import ReplyIcon from '@material-ui/icons/Reply';
-import { ForumPostsListByApproval, FormattedReferencedDataField, RepliesChip } from './ForumPostsList';
+import { ForumPostsListByApproval, RepliesChip } from './ForumPostsList';
 
 const approvedPostsListColumns = [
-  {
-    id: 'userID',
-    label: 'User',
-    format: (value) => (
-      <FormattedReferencedDataField
-        collection="users"
-        id={value}
-        field="displayName"
-        notFoundMessage="User not found"
-        render={(item) => <>{item}</>}
-      />
-    ),
-  },
-  {
-    id: 'title',
-    label: 'Post Title',
-  },
-  {
-    id: 'categoryID',
-    label: 'Category',
-    format: (value) => (
-      <FormattedReferencedDataField
-        collection="forum_categories"
-        id={value}
-        field="title"
-        notFoundMessage="Category not found"
-        render={(item) => <>{item}</>}
-      />
-    ),
-  },
   {
     id: 'approvedAt',
     label: 'Approved At',
@@ -52,7 +22,7 @@ const approvedPostsListColumns = [
 export default function ForumApprovedPostsList() {
   const theme = useTheme();
 
-  const approvedActionButtons = useMemo(() => ([
+  const approvedActionButtons = [
     {
       Icon: ReplyIcon,
     },
@@ -64,7 +34,7 @@ export default function ForumApprovedPostsList() {
       Icon: DeleteIcon,
       color: theme.palette.error.main,
     },
-  ]), [theme.palette.error.main, theme.palette.text.main]);
+  ];
 
   return (
     <Switch>
@@ -72,7 +42,7 @@ export default function ForumApprovedPostsList() {
       <Route exact>
         <ForumPostsListByApproval
           approved
-          columns={approvedPostsListColumns}
+          additionalColumns={approvedPostsListColumns}
           actionButtons={approvedActionButtons}
         />
       </Route>

--- a/src/components/Forum/ForumHomePage.js
+++ b/src/components/Forum/ForumHomePage.js
@@ -3,7 +3,8 @@ import React from 'react';
 import { Route } from 'react-router-dom';
 import * as ROUTES from '../../constants/routes';
 import ForumNavigationTabs from './ForumNavigationTabs';
-import ForumPostsListByApproval from './ForumPostsList';
+import ForumApprovedPosts from './ForumApprovedPosts';
+import ForumPendingPosts from './ForumPendingPosts';
 
 const useStyles = makeStyles((theme) => ({
   navigationContainer: {
@@ -13,17 +14,23 @@ const useStyles = makeStyles((theme) => ({
 
 export default function ForumHomePage() {
   const classes = useStyles();
+
   return (
     <div>
       <h1>Forum</h1>
+
       <div className={classes.navigationContainer}>
-        <ForumNavigationTabs />
+        {/* Tabs for top level routes, breadcrumbs for nested routes */}
+        <Route exact path={`(${ROUTES.FORUM_HOME}|${ROUTES.FORUM_APPROVED_POSTS})`}>
+          <ForumNavigationTabs />
+        </Route>
       </div>
+
       <Route exact path={ROUTES.FORUM_HOME}>
-        <ForumPostsListByApproval approved={false} />
+        <ForumPendingPosts />
       </Route>
-      <Route exact path={ROUTES.FORUM_APPROVED_POSTS}>
-        <ForumPostsListByApproval approved />
+      <Route path={ROUTES.FORUM_APPROVED_POSTS}>
+        <ForumApprovedPosts />
       </Route>
     </div>
   );

--- a/src/components/Forum/ForumPendingPosts.js
+++ b/src/components/Forum/ForumPendingPosts.js
@@ -2,40 +2,10 @@ import { useTheme } from '@material-ui/core';
 import CheckIcon from '@material-ui/icons/Check';
 import ClearIcon from '@material-ui/icons/Clear';
 import EditIcon from '@material-ui/icons/Edit';
-import React, { useMemo } from 'react';
-import { ForumPostsListByApproval, FormattedReferencedDataField } from './ForumPostsList';
+import React from 'react';
+import { ForumPostsListByApproval } from './ForumPostsList';
 
 const pendingPostsListColumns = [
-  {
-    id: 'userID',
-    label: 'User',
-    format: (value) => (
-      <FormattedReferencedDataField
-        collection="users"
-        id={value}
-        field="displayName"
-        notFoundMessage="User not found"
-        render={(item) => <>{item}</>}
-      />
-    ),
-  },
-  {
-    id: 'title',
-    label: 'Post Title',
-  },
-  {
-    id: 'categoryID',
-    label: 'Category',
-    format: (value) => (
-      <FormattedReferencedDataField
-        collection="forum_categories"
-        id={value}
-        field="title"
-        notFoundMessage="Category not found"
-        render={(item) => <>{item}</>}
-      />
-    ),
-  },
   {
     id: 'createdAt',
     label: 'Created At',
@@ -46,7 +16,7 @@ const pendingPostsListColumns = [
 export default function ForumPendingPostsList() {
   const theme = useTheme();
 
-  const pendingActionButtons = useMemo(() => ([
+  const pendingActionButtons = [
     {
       Icon: EditIcon,
       color: theme.palette.text.main,
@@ -59,12 +29,12 @@ export default function ForumPendingPostsList() {
       Icon: ClearIcon,
       color: theme.palette.error.main,
     },
-  ]), [theme.palette.error.main, theme.palette.success.main, theme.palette.text.main]);
+  ];
 
   return (
     <ForumPostsListByApproval
       approved={false}
-      columns={pendingPostsListColumns}
+      additionalColumns={pendingPostsListColumns}
       actionButtons={pendingActionButtons}
     />
   );

--- a/src/components/Forum/ForumPendingPosts.js
+++ b/src/components/Forum/ForumPendingPosts.js
@@ -1,0 +1,71 @@
+import { useTheme } from '@material-ui/core';
+import CheckIcon from '@material-ui/icons/Check';
+import ClearIcon from '@material-ui/icons/Clear';
+import EditIcon from '@material-ui/icons/Edit';
+import React, { useMemo } from 'react';
+import { ForumPostsListByApproval, FormattedReferencedDataField } from './ForumPostsList';
+
+const pendingPostsListColumns = [
+  {
+    id: 'userID',
+    label: 'User',
+    format: (value) => (
+      <FormattedReferencedDataField
+        collection="users"
+        id={value}
+        field="displayName"
+        notFoundMessage="User not found"
+        render={(item) => <>{item}</>}
+      />
+    ),
+  },
+  {
+    id: 'title',
+    label: 'Post Title',
+  },
+  {
+    id: 'categoryID',
+    label: 'Category',
+    format: (value) => (
+      <FormattedReferencedDataField
+        collection="forum_categories"
+        id={value}
+        field="title"
+        notFoundMessage="Category not found"
+        render={(item) => <>{item}</>}
+      />
+    ),
+  },
+  {
+    id: 'createdAt',
+    label: 'Created At',
+    format: (value) => (value ? value.toDate().toLocaleString() : 'Date not found'),
+  },
+];
+
+export default function ForumPendingPostsList() {
+  const theme = useTheme();
+
+  const pendingActionButtons = useMemo(() => ([
+    {
+      Icon: EditIcon,
+      color: theme.palette.text.main,
+    },
+    {
+      Icon: CheckIcon,
+      color: theme.palette.success.main,
+    },
+    {
+      Icon: ClearIcon,
+      color: theme.palette.error.main,
+    },
+  ]), [theme.palette.error.main, theme.palette.success.main, theme.palette.text.main]);
+
+  return (
+    <ForumPostsListByApproval
+      approved={false}
+      columns={pendingPostsListColumns}
+      actionButtons={pendingActionButtons}
+    />
+  );
+}

--- a/src/components/Forum/ForumPostsList/ForumPostsListByApproval.js
+++ b/src/components/Forum/ForumPostsList/ForumPostsListByApproval.js
@@ -14,6 +14,7 @@ import firebase from 'firebase/app';
 import 'firebase/firestore';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useState } from 'react';
+import FormattedReferencedDataField from './FormattedReferencedDataField';
 
 const useStyles = makeStyles({
   root: {
@@ -24,7 +25,40 @@ const useStyles = makeStyles({
   },
 });
 
-export default function ForumPostsListByApproval({ approved, columns, actionButtons }) {
+const columns = [
+  {
+    id: 'userID',
+    label: 'User',
+    format: (value) => (
+      <FormattedReferencedDataField
+        collection="users"
+        id={value}
+        field="displayName"
+        notFoundMessage="User not found"
+        render={(item) => <>{item}</>}
+      />
+    ),
+  },
+  {
+    id: 'title',
+    label: 'Post Title',
+  },
+  {
+    id: 'categoryID',
+    label: 'Category',
+    format: (value) => (
+      <FormattedReferencedDataField
+        collection="forum_categories"
+        id={value}
+        field="title"
+        notFoundMessage="Catego;ry not found"
+        render={(item) => <>{item}</>}
+      />
+    ),
+  },
+];
+
+export default function ForumPostsListByApproval({ approved, additionalColumns, actionButtons }) {
   const classes = useStyles();
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
@@ -72,11 +106,12 @@ export default function ForumPostsListByApproval({ approved, columns, actionButt
         <Table stickyHeader>
           <TableHead>
             <TableRow>
-              {columns.map((column) => (
-                <TableCell key={column.label}>
-                  <Chip color="primary" label={column.label} />
-                </TableCell>
-              ))}
+              {[columns, additionalColumns].map((columnsList) => (
+                columnsList.map((column) => (
+                  <TableCell key={column.label}>
+                    <Chip color="primary" label={column.label} />
+                  </TableCell>
+                ))))}
               <TableCell>
                 <Chip color="primary" label="Actions" />
               </TableCell>
@@ -85,14 +120,15 @@ export default function ForumPostsListByApproval({ approved, columns, actionButt
           <TableBody>
             {rows.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((row) => (
               <TableRow hover role="checkbox" tabIndex={-1} key={row.id}>
-                {columns.map((column) => {
-                  const value = row[column.id];
-                  return (
-                    <TableCell key={column.label}>
-                      {column.format ? column.format(value) : value}
-                    </TableCell>
-                  );
-                })}
+                {[columns, additionalColumns].map((columnsList) => (
+                  columnsList.map((column) => {
+                    const value = row[column.id];
+                    return (
+                      <TableCell key={column.label}>
+                        {column.format ? column.format(value) : value}
+                      </TableCell>
+                    );
+                  })))}
                 <TableCell>
                   {actionButtons.map(({ Icon, color }, i) => (
                     // Array will never change; index okay to use as key
@@ -122,7 +158,7 @@ export default function ForumPostsListByApproval({ approved, columns, actionButt
 
 ForumPostsListByApproval.propTypes = {
   approved: PropTypes.bool.isRequired,
-  columns: PropTypes.arrayOf(PropTypes.shape({
+  additionalColumns: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
     format: PropTypes.func,

--- a/src/components/Forum/ForumPostsList/ForumPostsListByApproval.js
+++ b/src/components/Forum/ForumPostsList/ForumPostsListByApproval.js
@@ -2,7 +2,7 @@ import Chip from '@material-ui/core/Chip';
 import IconButton from '@material-ui/core/IconButton';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import Paper from '@material-ui/core/Paper';
-import { makeStyles, useTheme } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
@@ -10,19 +10,10 @@ import TableContainer from '@material-ui/core/TableContainer';
 import TableHead from '@material-ui/core/TableHead';
 import TablePagination from '@material-ui/core/TablePagination';
 import TableRow from '@material-ui/core/TableRow';
-import CheckIcon from '@material-ui/icons/Check';
-import ClearIcon from '@material-ui/icons/Clear';
-import DeleteIcon from '@material-ui/icons/Delete';
-import EditIcon from '@material-ui/icons/Edit';
-import ReplyIcon from '@material-ui/icons/Reply';
 import firebase from 'firebase/app';
 import 'firebase/firestore';
 import PropTypes from 'prop-types';
-import React, {
-  useCallback, useEffect, useMemo, useState,
-} from 'react';
-import FormattedReferencedDataField from './FormattedReferencedDataField';
-import RepliesChip from './RepliesChip';
+import React, { useCallback, useEffect, useState } from 'react';
 
 const useStyles = makeStyles({
   root: {
@@ -33,90 +24,8 @@ const useStyles = makeStyles({
   },
 });
 
-const pendingPostsListColumns = [
-  {
-    id: 'userID',
-    label: 'User',
-    format: (value) => (
-      <FormattedReferencedDataField
-        collection="users"
-        id={value}
-        field="displayName"
-        notFoundMessage="User not found"
-        render={(item) => <>{item}</>}
-      />
-    ),
-  },
-  {
-    id: 'title',
-    label: 'Post Title',
-  },
-  {
-    id: 'categoryID',
-    label: 'Category',
-    format: (value) => (
-      <FormattedReferencedDataField
-        collection="forum_categories"
-        id={value}
-        field="title"
-        notFoundMessage="Category not found"
-        render={(item) => <>{item}</>}
-      />
-    ),
-  },
-  {
-    id: 'createdAt',
-    label: 'Created At',
-    format: (value) => (value ? value.toDate().toLocaleString() : 'Date not found'),
-  },
-];
-
-const approvedPostsListColumns = [
-  {
-    id: 'userID',
-    label: 'User',
-    format: (value) => (
-      <FormattedReferencedDataField
-        collection="users"
-        id={value}
-        field="displayName"
-        notFoundMessage="User not found"
-        render={(item) => <>{item}</>}
-      />
-    ),
-  },
-  {
-    id: 'title',
-    label: 'Post Title',
-  },
-  {
-    id: 'categoryID',
-    label: 'Category',
-    format: (value) => (
-      <FormattedReferencedDataField
-        collection="forum_categories"
-        id={value}
-        field="title"
-        notFoundMessage="Category not found"
-        render={(item) => <>{item}</>}
-      />
-    ),
-  },
-  {
-    id: 'approvedAt',
-    label: 'Approved At',
-    format: (value) => (value ? value.toDate().toLocaleString() : 'Date not found'),
-  },
-  {
-    id: 'id',
-    label: 'Replies',
-    format: (value) => <RepliesChip postID={value} />,
-  },
-];
-
-export default function ForumPostsListByApproval({ approved }) {
+export default function ForumPostsListByApproval({ approved, columns, actionButtons }) {
   const classes = useStyles();
-  const theme = useTheme();
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [loading, setLoading] = useState(false);
@@ -155,35 +64,6 @@ export default function ForumPostsListByApproval({ approved }) {
     setPage(0);
   }, []);
 
-  const columns = useMemo(() => (
-    approved ? approvedPostsListColumns : pendingPostsListColumns),
-  [approved]);
-
-  const actionButtons = useMemo(() => {
-    const iconsColorsList = approved
-      ? [
-        [ReplyIcon],
-        [EditIcon, theme.palette.text.main],
-        [DeleteIcon, theme.palette.error.main],
-      ]
-      : [
-        [EditIcon, theme.palette.text.main],
-        [CheckIcon, theme.palette.success.main],
-        [ClearIcon, theme.palette.error.main],
-      ];
-    return (
-      <>
-        {iconsColorsList.map(([Icon, color], i) => (
-          // Array will not change; index is okay to use as key
-          // eslint-disable-next-line react/no-array-index-key
-          <IconButton key={i}>
-            <Icon style={{ color }} />
-          </IconButton>
-        ))}
-      </>
-    );
-  }, [approved, theme.palette.error.main, theme.palette.success.main, theme.palette.text.main]);
-
   return (
     <Paper className={classes.root} elevation={0}>
       {loading && <LinearProgress />}
@@ -214,7 +94,13 @@ export default function ForumPostsListByApproval({ approved }) {
                   );
                 })}
                 <TableCell>
-                  {actionButtons}
+                  {actionButtons.map(({ Icon, color }, i) => (
+                    // Array will never change; index okay to use as key
+                    // eslint-disable-next-line react/no-array-index-key
+                    <IconButton key={i}>
+                      <Icon style={{ color }} />
+                    </IconButton>
+                  ))}
                 </TableCell>
               </TableRow>
             ))}
@@ -236,4 +122,13 @@ export default function ForumPostsListByApproval({ approved }) {
 
 ForumPostsListByApproval.propTypes = {
   approved: PropTypes.bool.isRequired,
+  columns: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    format: PropTypes.func,
+  })).isRequired,
+  actionButtons: PropTypes.arrayOf(PropTypes.shape({
+    Icon: PropTypes.elementType.isRequired,
+    color: PropTypes.string,
+  })).isRequired,
 };

--- a/src/components/Forum/ForumPostsList/index.js
+++ b/src/components/Forum/ForumPostsList/index.js
@@ -1,3 +1,3 @@
-import ForumPostsListByApproval from './ForumPostsListByApproval';
-
-export default ForumPostsListByApproval;
+export { default as RepliesChip } from './RepliesChip';
+export { default as FormattedReferencedDataField } from './FormattedReferencedDataField';
+export { default as ForumPostsListByApproval } from './ForumPostsListByApproval';

--- a/src/components/Forum/index.js
+++ b/src/components/Forum/index.js
@@ -1,4 +1,1 @@
-import ForumHomePage from './ForumHomePage';
-import ForumPostsListByApproval from './ForumPostsList/ForumPostsListByApproval';
-
-export { ForumHomePage, ForumPostsListByApproval };
+export { default } from './ForumHomePage';


### PR DESCRIPTION
…in the forum simpler

To test: go to the forum
- `/forum` to see pending posts
- `/forum/approved` to see approved posts

Just a simple refactor so behavior should be exact the same as before. This refactor should allow for  deeper nested routes to be implemented easier (TODO):
- `/forum/approved/:postID` to see details for a single approved post
- `/forum/approved/:postID/edit` to edit a post
etc.

The major refactor is simplifying `ForumPostsListByApproval`. The table's columns and action buttons are now defined in separate components `ForumApprovedPosts` and `ForumPendingPosts`. These new components are in charge of routing and rendering the different UIs for approved and pending posts respectively.

I also discovered a simpler way to import/export files in the `index.js` files.